### PR TITLE
Updated the model_package_name for the Layout Analysis 0.3.1 release.

### DIFF
--- a/cookbooks/upstage/aws/jumpstart/02_layout_analysis.ipynb
+++ b/cookbooks/upstage/aws/jumpstart/02_layout_analysis.ipynb
@@ -102,7 +102,7 @@
    },
    "outputs": [],
    "source": [
-    "model_package_name = \"Upstage-Document-Layout-Analysis-240704-r2\"\n",
+    "model_package_name = \"upstage-document-layout-analys-7cca10893dd43738b0c67ea590b3a058\"\n",
     "\n",
     "# Mapping for Model Packages\n",
     "model_package_map = {\n",


### PR DESCRIPTION
# desc 
Released Layout Analysis 0.3.1 on AWS Marketplace to address the issue of memory usage spikes when handling large files. 
The model_package_name has been updated in this PR to reflect the new version.