### PR TITLE
[docs] update model package name for dp-240910.2

### DIFF
--- a/aws/jumpstart/02_document_parse.ipynb
+++ b/aws/jumpstart/02_document_parse.ipynb
@@ -104,7 +104,7 @@
    },
    "outputs": [],
    "source": [
-    "model_package_name = \"upstage-document-parse-240924--dcb833ae236831afb9ab5180231f2fff\"\n",
+    "model_package_name = \"upstage-document-parse-240910--0c68001081d43268bb28a030131e92f0\"\n",
     "\n",
     "# Mapping for Model Packages\n",
     "model_package_map = {\n",


### PR DESCRIPTION
Released Document Parse version 240910.2. Updated the model package name to align with the new version.