### PR TITLE
feat(jumpstart): add Solar Embedding 2 cookbook (MKP-400)

### DIFF
--- a/aws/jumpstart/12_solar_embedding_2.ipynb
+++ b/aws/jumpstart/12_solar_embedding_2.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "source": [
     "Recommended instance types:\n",
-    "- **Real-time inference**: `ml.g6.xlarge` (or larger `ml.g6`/`ml.g6e`)\n",
+    "- **Real-time inference**: `ml.g6e.2xlarge` (or larger `ml.g6e`/`ml.g6`)\n",
     "- **Batch transform**: `ml.g6.xlarge` (or larger `ml.g6`) — `ml.g6e` is not available for batch transform\n",
     "\n",
     "**Note:** This package requires NVIDIA L4/L40S-class GPUs (`ml.g6`, `ml.g6e`). Older `ml.g5` (A10G) instances are **not supported** and will fail to start the container."
@@ -178,8 +178,7 @@
    "source": [
     "model_name = \"solar-embedding-2\"\n",
     "\n",
-    "# TODO: Load test pending. Confirm this instance handles expected concurrency + latency before publishing.\n",
-    "real_time_inference_instance_type = \"ml.g6.xlarge\""
+    "real_time_inference_instance_type = \"ml.g6e.2xlarge\""
    ]
   },
   {
@@ -497,7 +496,6 @@
     "\n",
     "transformer = batch_model.transformer(\n",
     "    instance_count=1,\n",
-    "    # TODO: Load test pending. Confirm this instance handles expected concurrency + latency before publishing.\n",
     "    instance_type=\"ml.g6.xlarge\",  # batch supports ml.g6 (g6e is real-time only)\n",
     "    output_path=f\"s3://{default_bucket}/{batch_output_prefix}/\",\n",
     "    accept=\"application/jsonlines\",\n",

--- a/aws/jumpstart/12_solar_embedding_2.ipynb
+++ b/aws/jumpstart/12_solar_embedding_2.ipynb
@@ -1,0 +1,618 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using Solar Embedding 2 on SageMaker JumpStart"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Solar Embedding 2** is a compact yet powerful multilingual embedding model purpose-built for retrieval, delivering strong performance in Korean, English, and beyond with a 32K-token context window. Fine-tuned for Retrieval-Augmented Generation (RAG), it remains far smaller than previous-generation embedding models, enabling lower-cost, higher-throughput serving without sacrificing quality. This model is divided into two specialized versions: `embedding-query`, optimized for embedding the user's question, and `embedding-passage`, designed for embedding documents to be searched. Utilizing these purpose-specific models increases retrieval efficiency, which leads to improved performance of Retrieval Augmented Generation (RAG) systems.\n",
+    "This sample notebook shows you how to deploy [Solar Embedding 2](url) using Amazon SageMaker.\n",
+    "\n",
+    "## Pre-requisites:\n",
+    "1. **Note**: This notebook contains elements which render correctly in Jupyter interface. Open this notebook from an Amazon SageMaker Notebook Instance or Amazon SageMaker Studio.\n",
+    "1. Ensure that IAM role used has **AmazonSageMakerFullAccess**\n",
+    "1. To deploy this ML model successfully, ensure that:\n",
+    "    1. Your IAM role has these three permissions and you have authority to make AWS Marketplace subscriptions in the AWS account used: \n",
+    "        1. **aws-marketplace:ViewSubscriptions**\n",
+    "        1. **aws-marketplace:Unsubscribe**\n",
+    "        1. **aws-marketplace:Subscribe**  \n",
+    "\n",
+    "## Contents:\n",
+    "1. [Subscribe to the model package](#1.-Subscribe-to-the-model-package)\n",
+    "2. [Create an endpoint and perform real-time inference](#2.-Create-an-endpoint-and-perform-real-time-inference)\n",
+    "   1. [Create an endpoint](#A.-Create-an-endpoint)\n",
+    "   2. [Prepare input payload](#B.-Prepare-input-payload)\n",
+    "   3. [Perform real-time inference](#C.-Perform-real-time-inference)\n",
+    "   4. [Perform semantic search](#D.-Perform-semantic-search)\n",
+    "3. [Perform batch transform](#3.-(Optional)-Perform-batch-transform)\n",
+    "4. [Clean-up](#4.-Clean-up)\n",
+    "   1. [Delete the endpoint](#A.-Delete-the-endpoint)\n",
+    "   2. [Delete the model](#B.-Delete-the-model)\n",
+    "    \n",
+    "\n",
+    "## Usage instructions\n",
+    "You can run this notebook one cell at a time (By using Shift+Enter for running a cell)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Subscribe to the model package"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To subscribe to the model package:\n",
+    "1. Open [Solar Embedding 2](url) model package listing page.\n",
+    "2. On the AWS Marketplace listing, click on the **Continue to subscribe** button.\n",
+    "3. On the **Subscribe to this software** page, review and click on **\"Accept Offer\"** if you and your organization agrees with EULA, pricing, and support terms. \n",
+    "4. Once you click on **Continue to configuration button** and then choose a **region**, you will see a **Product Arn** displayed. This is the model package ARN that you need to specify while creating a deployable model using Boto3. Copy the ARN corresponding to your region and specify the same in the following cell."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Recommended instance types:\n",
+    "- **Real-time inference**: `ml.g6.xlarge` (or larger `ml.g6`/`ml.g6e`)\n",
+    "- **Batch transform**: `ml.g6.xlarge` (or larger `ml.g6`) — `ml.g6e` is not available for batch transform\n",
+    "\n",
+    "**Note:** This package requires NVIDIA L4/L40S-class GPUs (`ml.g6`, `ml.g6e`). Older `ml.g5` (A10G) instances are **not supported** and will fail to start the container."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip -q install \"sagemaker<3\" boto3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import json\n",
+    "\n",
+    "import boto3\n",
+    "import sagemaker\n",
+    "from sagemaker import ModelPackage, get_execution_role"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "role = get_execution_role()\n",
+    "sagemaker_session = sagemaker.Session()\n",
+    "\n",
+    "sagemaker_runtime = boto3.client(\"sagemaker-runtime\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Choose one of our model packages\n",
+    "\n",
+    "model_package_name = \"embed-v2-260615-0\"\n",
+    "\n",
+    "# TODO: Solar Embedding 2 is pre-release. The account IDs below are placeholders --\n",
+    "# replace each with the AWS Marketplace publisher account ID for the corresponding\n",
+    "# region once the model package is published.\n",
+    "# Confirmed (still private, fill in on release): us-west-2, us-east-1\n",
+    "# Mapping for Model Packages\n",
+    "model_package_map = {\n",
+    "    \"us-east-1\": f\"arn:aws:sagemaker:us-east-1:000000000000:model-package/{model_package_name}\",\n",
+    "    \"us-east-2\": f\"arn:aws:sagemaker:us-east-2:000000000000:model-package/{model_package_name}\",\n",
+    "    \"us-west-1\": f\"arn:aws:sagemaker:us-west-1:000000000000:model-package/{model_package_name}\",\n",
+    "    \"us-west-2\": f\"arn:aws:sagemaker:us-west-2:000000000000:model-package/{model_package_name}\",\n",
+    "    \"ca-central-1\": f\"arn:aws:sagemaker:ca-central-1:000000000000:model-package/{model_package_name}\",\n",
+    "    \"eu-central-1\": f\"arn:aws:sagemaker:eu-central-1:000000000000:model-package/{model_package_name}\",\n",
+    "    \"eu-west-1\": f\"arn:aws:sagemaker:eu-west-1:000000000000:model-package/{model_package_name}\",\n",
+    "    \"eu-west-2\": f\"arn:aws:sagemaker:eu-west-2:000000000000:model-package/{model_package_name}\",\n",
+    "    \"eu-west-3\": f\"arn:aws:sagemaker:eu-west-3:000000000000:model-package/{model_package_name}\",\n",
+    "    \"eu-north-1\": f\"arn:aws:sagemaker:eu-north-1:000000000000:model-package/{model_package_name}\",\n",
+    "    \"ap-southeast-1\": f\"arn:aws:sagemaker:ap-southeast-1:000000000000:model-package/{model_package_name}\",\n",
+    "    \"ap-southeast-2\": f\"arn:aws:sagemaker:ap-southeast-2:000000000000:model-package/{model_package_name}\",\n",
+    "    \"ap-northeast-2\": f\"arn:aws:sagemaker:ap-northeast-2:000000000000:model-package/{model_package_name}\",\n",
+    "    \"ap-northeast-1\": f\"arn:aws:sagemaker:ap-northeast-1:000000000000:model-package/{model_package_name}\",\n",
+    "    \"ap-south-1\": f\"arn:aws:sagemaker:ap-south-1:000000000000:model-package/{model_package_name}\",\n",
+    "    \"sa-east-1\": f\"arn:aws:sagemaker:sa-east-1:000000000000:model-package/{model_package_name}\",\n",
+    "}\n",
+    "\n",
+    "\n",
+    "region = sagemaker_session.boto_region_name\n",
+    "if region not in model_package_map.keys():\n",
+    "    raise Exception(f\"Current boto3 session region {region} is not supported.\")\n",
+    "\n",
+    "model_package_arn = model_package_map[region]\n",
+    "\n",
+    "print(f\"Model Package: '{model_package_arn}'\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Create an endpoint and perform real-time inference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you want to understand how real-time inference with Amazon SageMaker works, see [Documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-hosting.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model_name = \"solar-embedding-2\"\n",
+    "\n",
+    "# TODO: Load test pending. Confirm this instance handles expected concurrency + latency before publishing.\n",
+    "real_time_inference_instance_type = \"ml.g6.xlarge\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### A. Create an endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# create a deployable model from the model package.\n",
+    "model = ModelPackage(\n",
+    "    role=role, model_package_arn=model_package_arn, sagemaker_session=sagemaker_session\n",
+    ")\n",
+    "\n",
+    "endpoint_name = sagemaker.utils.name_from_base(model_name)\n",
+    "print(f\"endpoint name: '{endpoint_name}'\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Deploy the model\n",
+    "model.deploy(1, real_time_inference_instance_type, endpoint_name=endpoint_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once endpoint has been created, you would be able to perform real-time inference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### B. Prepare input payload"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We support request/response payload compatible to OpenAI's Embeddings endpoint.\n",
+    "\n",
+    "Supported parameters:\n",
+    "- input(list of string or string)*: A single text string, or an array of texts to embed.\n",
+    "- model(string)*: Name of the model utilized to carry out the embedding. Current available models are `embedding-query` and `embedding-passage`.\n",
+    "\n",
+    "**required*\n",
+    "\n",
+    "The model produces native **1024-dimensional** embeddings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Input is single string\n",
+    "input = {\n",
+    "    \"model\": \"embedding-query\",\n",
+    "    \"input\": \"How is the performance of Solar embeddings?\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Input is a list of strings\n",
+    "input = {\n",
+    "    \"model\": \"embedding-passage\",\n",
+    "    \"input\": [\n",
+    "        \"Solar embeddings are awesome.\",\n",
+    "        \"Solar embedding model demonstrates strong performance in multiple languages.\",\n",
+    "    ],\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### C. Perform real-time inference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# real-time inference\n",
+    "def invoke_endpoint(endpoint_name, payload):\n",
+    "    response = sagemaker_runtime.invoke_endpoint(\n",
+    "        EndpointName=endpoint_name,\n",
+    "        ContentType=\"application/json\",\n",
+    "        Body=json.dumps(payload),\n",
+    "    )\n",
+    "    data = response[\"Body\"].read().decode(\"utf-8\")\n",
+    "\n",
+    "    return data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = json.loads(invoke_endpoint(endpoint_name, input))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(\"embeddings: \")\n",
+    "print(response[\"data\"][0][\"embedding\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### D. Perform semantic search"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "query = \"A man is eating pasta.\"\n",
+    "\n",
+    "documents = [\n",
+    "    \"A man is eating food.\",\n",
+    "    \"A man is walking around the park.\",\n",
+    "    \"A man is running fast.\",\n",
+    "    \"A man is eating Italian food.\",\n",
+    "    \"A Rabbit is sleeping.\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# get query embedding\n",
+    "query_embedding_response = json.loads(\n",
+    "    invoke_endpoint(\n",
+    "        endpoint_name, {\"model\": \"embedding-query\", \"input\": query}\n",
+    "    )\n",
+    ")\n",
+    "query_embedding = query_embedding_response[\"data\"][0][\"embedding\"]\n",
+    "\n",
+    "# get passage embeddings\n",
+    "passage_embedding_response = json.loads(\n",
+    "    invoke_endpoint(\n",
+    "        endpoint_name, {\"model\": \"embedding-passage\", \"input\": documents}\n",
+    "    )\n",
+    ")\n",
+    "passage_embeddings = [\n",
+    "    embeds_object[\"embedding\"] for embeds_object in passage_embedding_response[\"data\"]\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from typing import List\n",
+    "import math\n",
+    "\n",
+    "\n",
+    "def cosine_similarity(vec1: List[float], vec2: List[float]) -> float:\n",
+    "    dot_product = sum(v1 * v2 for v1, v2 in zip(vec1, vec2))\n",
+    "\n",
+    "    magnitude1 = math.sqrt(sum(v**2 for v in vec1))\n",
+    "    magnitude2 = math.sqrt(sum(v**2 for v in vec2))\n",
+    "\n",
+    "    if magnitude1 == 0 or magnitude2 == 0:\n",
+    "        return 0\n",
+    "    else:\n",
+    "        return dot_product / (magnitude1 * magnitude2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "similarities = []\n",
+    "for passage_embedding in passage_embeddings:\n",
+    "    similarities.append(cosine_similarity(query_embedding, passage_embedding))\n",
+    "\n",
+    "print(\"Top 1 document is:\")\n",
+    "print(documents[similarities.index(max(similarities))])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. (Optional) Perform batch transform\n",
+    "\n",
+    "For large-scale, asynchronous embedding of many texts, this package also supports SageMaker **Batch Transform**. Input is read from S3, processed without a persistent endpoint, and written back to S3 — using the **same model package ARN** as the real-time endpoint (no separate subscription required).\n",
+    "\n",
+    "The input is **JSON Lines** (`.jsonl`): one embedding request per line, e.g. `{\"model\": \"embedding-passage\", \"input\": \"<text or list of texts>\"}`. SageMaker splits the file by line (`SplitType=Line`), sends each line as one `/invocations` request (`SingleRecord`), and reassembles the responses in input order (`AssembleWith=Line`) into a `<input-filename>.out` object.\n",
+    "\n",
+    "Batch Transform supports `ml.g6` instance types (`ml.g6e` is real-time only)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "\n",
+    "s3_client = boto3.client(\"s3\")\n",
+    "default_bucket = sagemaker_session.default_bucket()\n",
+    "batch_input_prefix = \"solar-embedding-2/batch/input\"\n",
+    "batch_output_prefix = \"solar-embedding-2/batch/output\"\n",
+    "\n",
+    "# Each line is one embedding request: {\"model\": <model>, \"input\": <string or list of strings>}.\n",
+    "batch_records = [\n",
+    "    {\"model\": \"embedding-passage\", \"input\": \"Solar embeddings are awesome.\"},\n",
+    "    {\"model\": \"embedding-passage\", \"input\": \"Upstage builds frontier AI for enterprises.\"},\n",
+    "    {\"model\": \"embedding-passage\", \"input\": \"Embeddings are a core building block of RAG.\"},\n",
+    "]\n",
+    "\n",
+    "# Write the records as JSON Lines (one JSON object per line)\n",
+    "input_file = \"embed_batch_input.jsonl\"\n",
+    "with open(input_file, \"w\", encoding=\"utf-8\") as f:\n",
+    "    for record in batch_records:\n",
+    "        f.write(json.dumps(record, ensure_ascii=False) + \"\\n\")\n",
+    "\n",
+    "# Upload to S3\n",
+    "s3_client.upload_file(input_file, default_bucket, f\"{batch_input_prefix}/{input_file}\")\n",
+    "input_s3_uri = f\"s3://{default_bucket}/{batch_input_prefix}/{input_file}\"\n",
+    "print(f\"Uploaded input to: {input_s3_uri}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Create a transformer from the same model package\n",
+    "# (Batch Transform reuses the real-time subscription -- no separate subscription needed).\n",
+    "batch_model = ModelPackage(\n",
+    "    role=role, model_package_arn=model_package_arn, sagemaker_session=sagemaker_session\n",
+    ")\n",
+    "\n",
+    "transformer = batch_model.transformer(\n",
+    "    instance_count=1,\n",
+    "    # TODO: Load test pending. Confirm this instance handles expected concurrency + latency before publishing.\n",
+    "    instance_type=\"ml.g6.xlarge\",  # batch supports ml.g6 (g6e is real-time only)\n",
+    "    output_path=f\"s3://{default_bucket}/{batch_output_prefix}/\",\n",
+    "    accept=\"application/jsonlines\",\n",
+    "    assemble_with=\"Line\",  # reassemble responses line-by-line, in input order\n",
+    "    strategy=\"SingleRecord\",  # one input line -> one /invocations request\n",
+    "    max_payload=6,  # MB\n",
+    ")\n",
+    "\n",
+    "# Run the batch job\n",
+    "transformer.transform(\n",
+    "    data=f\"s3://{default_bucket}/{batch_input_prefix}/\",\n",
+    "    content_type=\"application/jsonlines\",\n",
+    "    split_type=\"Line\",  # split the .jsonl input by line\n",
+    "    wait=True,\n",
+    ")\n",
+    "\n",
+    "print(f\"Batch output: {transformer.output_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Each input line i maps to output line i in \"<input-filename>.out\".\n",
+    "output_key = f\"{batch_output_prefix}/{input_file}.out\"\n",
+    "body = (\n",
+    "    s3_client.get_object(Bucket=default_bucket, Key=output_key)[\"Body\"]\n",
+    "    .read()\n",
+    "    .decode(\"utf-8\")\n",
+    ")\n",
+    "\n",
+    "for line in body.splitlines():\n",
+    "    if not line.strip():\n",
+    "        continue\n",
+    "    result = json.loads(line)\n",
+    "    embedding = result[\"data\"][0][\"embedding\"]\n",
+    "    print(f\"dim={len(embedding)} first3={embedding[:3]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Clean-up"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### A. Delete the endpoint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that you have successfully performed a real-time inference, you can delete the endpoint and avoid being charged."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model.sagemaker_session.delete_endpoint(endpoint_name)\n",
+    "model.sagemaker_session.delete_endpoint_config(endpoint_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### B. Delete the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model.delete_model()"
+   ]
+  }
+ ],
+ "metadata": {
+  "instance_type": "ml.t3.medium",
+  "kernelspec": {
+   "display_name": "fastapi",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## 요약
- 새 쿡북 `aws/jumpstart/12_solar_embedding_2.ipynb` — SageMaker JumpStart 용 Solar Embedding 2.
- v1 (`06_solar_embedding_large.ipynb`) 셀 구조 그대로 가져오고 v2 차이점만 반영: native **1024-d** 임베딩 (PCA / `dimensions` 파라미터 없음), 새 alias `embedding-query` / `embedding-passage`, two-field `{model, input}` payload 스키마, real-time 기본 인스턴스 `ml.g6e.2xlarge` (부하 테스트 결과 반영), batch 기본 `ml.g6.xlarge`.
- Pre-release 상태: 16-region ARN map 은 `000000000000` placeholder + TODO 코멘트, cell-3 listing URL 도 placeholder.
- v1 leftover 정리: 미사용 `sseclient` install + import 제거, 미사용 `content_type` 변수 제거, "Either" / `compitable` / `Chat completion endpoint` 오타 수정.

## Test plan
- [x] `sagemaker<3` 설치 + import
- [x] `ml.g6.xlarge` 엔드포인트 배포 → `InService` (※ 초기 검증 시점 default. 현재 default는 `ml.g6e.2xlarge`)
- [x] 실시간 invoke (단일 문자열 + 배열)
- [x] 임베딩 차원 1024 확인
- [x] Semantic search top-1 = "A man is eating Italian food." (의미 기반 retrieval 정상)
- [x] Endpoint / EndpointConfig / Model cleanup
- [ ] Batch transform — 테스트 계정의 `ml.g6.xlarge for transform job usage` quota = 0 이라 **스킵**. 코드 구조는 검증된 실시간 invoke path 와 동일. quota grant 후 또는 publisher e2e 시점에 재검증 필요.

## Publish 전 TODO
- Marketplace publish 후 `cell-9` (region map) 16개 region account ID 실값으로 교체
- `cell-3` listing URL 채우기
- `cell-32` batch 인스턴스 부하 테스트 (service quota grant 후) — 결과에 따라 instance type 조정
🤖 Generated with [Claude Code](https://claude.com/claude-code)